### PR TITLE
fix: add sleep for Feynman upgrade

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type CrossChainConfig struct {
 	DestChainID        uint16  `json:"dest_chain_id"`
 	MonitorChannelList []uint8 `json:"monitor_channel_list"`
 	CompetitionMode    bool    `json:"competition_mode"`
+	BreatheBlockDelay  uint64  `json:"breathe_block_delay"`
 }
 
 func (cfg *CrossChainConfig) Validate() {

--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,8 @@
     "source_chain_id": 1,
     "dest_chain_id": 2,
     "monitor_channel_list": [1, 2, 3, 8, 9],
-    "competition_mode": true
+    "competition_mode": true,
+    "breathe_block_delay": 20
   },
   "bbc_config": {
     "rpc_addrs": [

--- a/config/config.json
+++ b/config/config.json
@@ -4,7 +4,7 @@
     "dest_chain_id": 2,
     "monitor_channel_list": [1, 2, 3, 8, 9],
     "competition_mode": true,
-    "breathe_block_delay": 20
+    "breathe_block_delay": 5
   },
   "bbc_config": {
     "rpc_addrs": [

--- a/executor/bsc_executor.go
+++ b/executor/bsc_executor.go
@@ -227,7 +227,7 @@ func (executor *BSCExecutor) SyncTendermintLightClientHeader(height uint64) (com
 		return common.Hash{}, err
 	}
 
-	//TODO optimize
+	// TODO optimize
 tryAgain:
 	header, err := executor.bbcExecutor.QueryTendermintHeader(int64(height))
 	if err != nil {
@@ -276,6 +276,13 @@ tryAgain:
 }
 
 func (executor *BSCExecutor) CallBuildInSystemContract(channelID relayercommon.CrossChainChannelID, height, sequence uint64, msgBytes, proofBytes []byte, nonce uint64) (common.Hash, error) {
+	// If the channelID is Staking channel, delayed processing ensures that the order of the transaction
+	if uint8(channelID) == uint8(8) {
+		if executor.cfg.CrossChainConfig.BreatheBlockDelay > 0 {
+			time.Sleep(time.Duration(executor.cfg.CrossChainConfig.BreatheBlockDelay) * time.Second)
+		}
+	}
+
 	txOpts, err := executor.getTransactor(nonce)
 	if err != nil {
 		return common.Hash{}, err


### PR DESCRIPTION
### Description

This pr is to add sleep when relaying StakingChannel's package.

### Rationale

To make sure the order of transaction is as expected.
